### PR TITLE
Perform triangulation using compiled backend

### DIFF
--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -1,3 +1,5 @@
+import typing
+
 import numpy as np
 
 from napari._vispy.layers.base import VispyBaseLayer
@@ -7,9 +9,13 @@ from napari._vispy.visuals.shapes import ShapesVisual
 from napari.settings import get_settings
 from napari.utils.events import disconnect_events
 
+if typing.TYPE_CHECKING:
+    from napari.layers import Shapes
+
 
 class VispyShapesLayer(VispyBaseLayer):
     node: ShapesVisual
+    layer: 'Shapes'
 
     def __init__(self, layer) -> None:
         node = ShapesVisual()

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -208,10 +208,17 @@ def _fresh_settings(monkeypatch):
     """
     from napari import settings
     from napari.settings import NapariSettings
+    from napari.settings._experimental import ExperimentalSettings
 
     # prevent the developer's config file from being used if it exists
     cp = NapariSettings.__private_attributes__['_config_path']
     monkeypatch.setattr(cp, 'default', None)
+
+    monkeypatch.setattr(
+        ExperimentalSettings.__fields__['compiled_triangulation'],
+        'default',
+        True,
+    )
 
     # calling save() with no config path is normally an error
     # here we just have save() return if called without a valid path
@@ -224,8 +231,8 @@ def _fresh_settings(monkeypatch):
 
     monkeypatch.setattr(NapariSettings, 'save', _mock_save)
 
-    # this makes sure that we start with fresh settings for every test.
     settings._SETTINGS = None
+    # this makes sure that we start with fresh settings for every test.
     return
 
 

--- a/napari/layers/shapes/_accelerated_triangulate.py
+++ b/napari/layers/shapes/_accelerated_triangulate.py
@@ -599,3 +599,37 @@ def remove_path_duplicates(path: np.ndarray, closed: bool) -> np.ndarray:
             index += 1
 
     return new_path
+
+
+@njit(cache=True)
+def create_box_from_bounding(bounding_box: np.ndarray) -> np.ndarray:
+    """Creates the axis aligned interaction box of a bounding box
+
+    Parameters
+    ----------
+    bounding_box : np.ndarray
+        2x2 array of the bounding box. The first row is the minimum values and
+        the second row is the maximum values
+
+    Returns
+    -------
+    box : np.ndarray
+        9x2 array of vertices of the interaction box. The first 8 points are
+        the corners and midpoints of the box in clockwise order starting in the
+        upper-left corner. The last point is the center of the box
+    """
+    x_min = bounding_box[0, 0]
+    x_max = bounding_box[1, 0]
+    y_min = bounding_box[0, 1]
+    y_max = bounding_box[1, 1]
+    result = np.empty((9, 2), dtype=np.float32)
+    result[0] = [x_min, y_min]
+    result[1] = [(x_min + x_max) / 2, y_min]
+    result[2] = [x_max, y_min]
+    result[3] = [x_max, (y_min + y_max) / 2]
+    result[4] = [x_max, y_max]
+    result[5] = [(x_min + x_max) / 2, y_max]
+    result[6] = [x_min, y_max]
+    result[7] = [x_min, (y_min + y_max) / 2]
+    result[8] = [(x_min + x_max) / 2, (y_min + y_max) / 2]
+    return result

--- a/napari/layers/shapes/_shapes_constants.py
+++ b/napari/layers/shapes/_shapes_constants.py
@@ -95,4 +95,9 @@ shape_classes = {
     ShapeType.LINE: Line,
     ShapeType.PATH: Path,
     ShapeType.POLYGON: Polygon,
+    str(ShapeType.RECTANGLE): Rectangle,
+    str(ShapeType.ELLIPSE): Ellipse,
+    str(ShapeType.LINE): Line,
+    str(ShapeType.PATH): Path,
+    str(ShapeType.POLYGON): Polygon,
 }

--- a/napari/layers/shapes/_shapes_models/_polygon_base.py
+++ b/napari/layers/shapes/_shapes_models/_polygon_base.py
@@ -1,8 +1,13 @@
 import numpy as np
 from scipy.interpolate import splev, splprep
 
-from napari.layers.shapes._shapes_models.shape import Shape
-from napari.layers.shapes._shapes_utils import create_box
+from napari.layers.shapes._shapes_models.shape import (
+    Shape,
+    remove_path_duplicates,
+)
+from napari.layers.shapes._shapes_utils import (
+    create_box_from_bounding,
+)
 from napari.utils.translations import trans
 
 
@@ -90,39 +95,41 @@ class PolygonBase(Shape):
 
     def _update_displayed_data(self) -> None:
         """Update the data that is to be displayed."""
+        self._clean_cache()
         # Raw vertices
         data = self.data_displayed
 
-        # splprep fails if two adjacent values are identical, which happens
-        # when a point was just created and the new potential point is set to exactly the same
-        # to prevent issues, we remove the extra points.
-        duplicates = np.isclose(data, np.roll(data, 1, axis=0))
-        # cannot index with bools directly (flattens by design)
-        data_spline = data[~np.all(duplicates, axis=1)]
+        # # splprep fails if two adjacent values are identical, which happens
+        # # when a point was just created and the new potential point is set to exactly the same
+        # # to prevent issues, we remove the extra points.
+        # duplicates = np.isclose(data, np.roll(data, 1, axis=0))
+        # # cannot index with bools directly (flattens by design)
+        # data_spline = data[~np.all(duplicates, axis=1)]
 
-        if (
-            self.interpolation_order > 1
-            and len(data_spline) > self.interpolation_order
-        ):
-            data = data_spline.copy()
-            if self._closed:
-                data = np.append(data, data[:1], axis=0)
+        if self.interpolation_order > 1:
+            data_spline = remove_path_duplicates(data, closed=True)
 
-            tck, *_ = splprep(
-                data.T, s=0, k=self.interpolation_order, per=self._closed
-            )
+            if len(data_spline) > self.interpolation_order:
+                data = data_spline.copy()
+                if self._closed:
+                    data = np.append(data, data[:1], axis=0)
 
-            # the number of sampled data points might need to be carefully thought
-            # about (might need to change with image scale?)
-            u = np.linspace(0, 1, self.interpolation_sampling * len(data))
+                tck, *_ = splprep(
+                    data.T, s=0, k=self.interpolation_order, per=self._closed
+                )
 
-            # get interpolated data (discard last element which is a copy)
-            data = np.stack(splev(u, tck), axis=1)[:-1]
+                # the number of sampled data points might need to be carefully thought
+                # about (might need to change with image scale?)
+                u = np.linspace(0, 1, self.interpolation_sampling * len(data))
+
+                # get interpolated data (discard last element which is a copy)
+                data = np.stack(splev(u, tck), axis=1)[:-1].astype(np.float32)
 
         # For path connect every all data
         self._set_meshes(data, face=self._filled, closed=self._closed)
-        self._box = create_box(self.data_displayed)
+        bbox = self._bounding_box[:, self.dims_displayed]
+        self._box = create_box_from_bounding(bbox)
 
-        self.slice_key = np.round(
+        self.slice_key = np.rint(
             self._bounding_box[:, self.dims_not_displayed]
-        ).astype('int')
+        ).astype(int)

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -14,6 +14,10 @@ from napari.layers.shapes._shapes_models import (
 )
 from napari.layers.shapes._shapes_utils import triangulate_face
 
+BETTER_TRIANGULATION = (
+    'triangle' in sys.modules or 'PartSegCore_compiled_backend' in sys.modules
+)
+
 
 def test_rectangle1():
     """Test creating Rectangle by four corners."""
@@ -144,7 +148,7 @@ def test_polygon():
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
-    expected_face = (6, 2) if 'triangle' in sys.modules else (8, 2)
+    expected_face = (6, 2) if BETTER_TRIANGULATION else (8, 2)
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == expected_face
 

--- a/napari/layers/shapes/_shapes_models/ellipse.py
+++ b/napari/layers/shapes/_shapes_models/ellipse.py
@@ -88,6 +88,7 @@ class Ellipse(Shape):
     def _update_displayed_data(self) -> None:
         """Update the data that is to be displayed."""
         # Build boundary vertices with num_segments
+        self._clean_cache()
         vertices, triangles = triangulate_ellipse(self.data_displayed)
         self._set_meshes(vertices[1:-1], face=False)
         self._face_vertices = vertices
@@ -126,3 +127,4 @@ class Ellipse(Shape):
                 np.max(self._data, axis=0),
             ]
         )
+        self._clean_cache()

--- a/napari/layers/shapes/_shapes_models/line.py
+++ b/napari/layers/shapes/_shapes_models/line.py
@@ -74,6 +74,7 @@ class Line(Shape):
     def _update_displayed_data(self) -> None:
         """Update the data that is to be displayed."""
         # For path connect every all data
+        self._clean_cache()
         self._set_meshes(self.data_displayed, face=False, closed=False)
         self._box = create_box(self.data_displayed)
 

--- a/napari/layers/shapes/_shapes_models/rectangle.py
+++ b/napari/layers/shapes/_shapes_models/rectangle.py
@@ -79,10 +79,12 @@ class Rectangle(Shape):
     def _update_displayed_data(self) -> None:
         """Update the data that is to be displayed."""
         # Add four boundary lines and then two triangles for each
-        self._set_meshes(self.data_displayed, face=False)
-        self._face_vertices = self.data_displayed
+        self._clean_cache()
+        data_displayed = self.data_displayed
+        self._set_meshes(data_displayed, face=False)
+        self._face_vertices = data_displayed
         self._face_triangles = np.array([[0, 1, 2], [0, 2, 3]])
-        self._box = rectangle_to_box(self.data_displayed)
+        self._box = rectangle_to_box(data_displayed)
         self.slice_key = self._bounding_box[:, self.dims_not_displayed].astype(
             'int'
         )

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import cached_property
 
 import numpy as np
 import numpy.typing as npt
@@ -12,8 +13,21 @@ from napari.layers.shapes._shapes_utils import (
     triangulate_edge,
     triangulate_face,
 )
+from napari.settings import get_settings
 from napari.utils.misc import argsort
 from napari.utils.translations import trans
+
+try:
+    from PartSegCore_compiled_backend.triangulate import (
+        triangulate_path_edge_py,
+        triangulate_polygon_numpy_li,
+        triangulate_polygon_with_edge_numpy_li,
+    )
+
+except ImportError:
+    triangulate_path_edge_py = None
+    triangulate_polygon_numpy_li = None
+    triangulate_polygon_with_edge_numpy_li = None
 
 
 def _remove_path_duplicates_np(data: np.ndarray, closed: bool):
@@ -147,6 +161,16 @@ class Shape(ABC):
         self._data: npt.NDArray
         self._bounding_box = np.empty((0, self.ndisplay))
 
+    def __new__(cls, *args, **kwargs):
+        if (
+            get_settings().experimental.compiled_triangulation
+            and triangulate_path_edge_py is not None
+        ):
+            cls._set_meshes = cls._set_meshes_compiled
+        else:
+            cls._set_meshes = cls._set_meshes_py
+        return super().__new__(cls)
+
     @property
     @abstractmethod
     def data(self):
@@ -186,7 +210,7 @@ class Shape(ABC):
         self._dims_order = dims_order
         self._update_displayed_data()
 
-    @property
+    @cached_property
     def dims_displayed(self):
         """tuple: Dimensions that are displayed."""
         return self.dims_order[-self.ndisplay :]
@@ -205,7 +229,7 @@ class Shape(ABC):
         """tuple: Dimensions that are not displayed."""
         return self.dims_order[: -self.ndisplay]
 
-    @property
+    @cached_property
     def data_displayed(self):
         """(N, 2) array: Vertices of the shape that are currently displayed."""
         return self.data[:, self.dims_displayed]
@@ -230,7 +254,72 @@ class Shape(ABC):
     def z_index(self, z_index):
         self._z_index = z_index
 
-    def _set_meshes(
+    def _set_meshes_compiled(
+        self,
+        data: npt.NDArray,
+        closed: bool = True,
+        face: bool = True,
+        edge: bool = True,
+    ) -> None:
+        """Sets the face and edge meshes from a set of points.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Nx2 or Nx3 array specifying the shape to be triangulated
+        closed : bool
+            Bool which determines if the edge is closed or not
+        face : bool
+            Bool which determines if the face need to be traingulated
+        edge : bool
+            Bool which determines if the edge need to be traingulated
+        """
+        if data.shape[1] == 3:
+            self._set_meshes_py(data, closed=closed, face=face, edge=edge)
+            return
+
+        # if we are computing both edge and face triangles, we can do so
+        # with a single call to the compiled backend
+        if edge and face:
+            (triangles, vertices), (centers, offsets, edge_triangles) = (
+                triangulate_polygon_with_edge_numpy_li([data])
+            )
+            self._edge_vertices = centers
+            self._edge_offsets = offsets
+            self._edge_triangles = edge_triangles
+            self._face_vertices = vertices
+            self._face_triangles = triangles
+            return
+
+        # otherwise, we make individual calls to specialized functions
+        if edge:
+            centers, offsets, triangles = triangulate_path_edge_py(
+                data, closed=closed
+            )
+            self._edge_vertices = centers
+            self._edge_offsets = offsets
+            self._edge_triangles = triangles
+        else:
+            self._edge_vertices = np.empty((0, self.ndisplay))
+            self._edge_offsets = np.empty((0, self.ndisplay))
+            self._edge_triangles = np.empty((0, 3), dtype=np.uint32)
+        if face:
+            triangles, vertices = triangulate_polygon_numpy_li([data])
+            self._face_vertices = vertices
+            self._face_triangles = triangles
+        else:
+            self._face_vertices = np.empty((0, self.ndisplay))
+            self._face_triangles = np.empty((0, 3), dtype=np.uint32)
+
+    def _set_meshes(  # noqa: B027
+        self,
+        data: npt.NDArray,
+        closed: bool = True,
+        face: bool = True,
+        edge: bool = True,
+    ) -> None: ...
+
+    def _set_meshes_py(
         self,
         data: npt.NDArray,
         closed: bool = True,
@@ -336,6 +425,7 @@ class Shape(ABC):
                 np.max(self._data, axis=0),
             ]
         )
+        self._clean_cache()
 
     def shift(self, shift: npt.NDArray) -> None:
         """Performs a 2D shift on the shape
@@ -354,6 +444,7 @@ class Shape(ABC):
         self._bounding_box[:, self.dims_displayed] = (
             self._bounding_box[:, self.dims_displayed] + shift
         )
+        self._clean_cache()
 
     def scale(self, scale, center=None):
         """Performs a scaling on the shape
@@ -508,3 +599,9 @@ class Shape(ABC):
             mask = mask_p
 
         return mask
+
+    def _clean_cache(self) -> None:
+        if 'dims_displayed' in self.__dict__:
+            del self.__dict__['dims_displayed']
+        if 'data_displayed' in self.__dict__:
+            del self.__dict__['data_displayed']

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -22,10 +22,12 @@ except ModuleNotFoundError:
 
 try:
     from napari.layers.shapes._accelerated_triangulate import (
+        create_box_from_bounding as acc_create_box_from_bounding,
         generate_2D_edge_meshes as acc_generate_2D_edge_meshes,
     )
 except ImportError:
     acc_generate_2D_edge_meshes = None
+    acc_create_box_from_bounding = None
 
 
 def _is_convex(poly: npt.NDArray) -> bool:
@@ -383,6 +385,41 @@ def point_to_lines(point, lines):
     location = line_loc[index]
 
     return index, location
+
+
+def create_box_from_bounding(bounding_box: npt.NDArray) -> npt.NDArray:
+    """Creates the axis aligned interaction box of a bounding box
+
+    Parameters
+    ----------
+    bounding_box : np.ndarray
+        2x2 array of the bounding box. The first row is the minimum values and
+        the second row is the maximum values
+
+    Returns
+    -------
+    box : np.ndarray
+        9x2 array of vertices of the interaction box. The first 8 points are
+        the corners and midpoints of the box in clockwise order starting in the
+        upper-left corner. The last point is the center of the box
+    """
+    tl = bounding_box[(0, 0), (0, 1)]
+    br = bounding_box[(1, 1), (0, 1)]
+    tr = bounding_box[(1, 0), (0, 1)]
+    bl = bounding_box[(0, 1), (0, 1)]
+    return np.array(
+        [
+            tl,
+            (tl + tr) / 2,
+            tr,
+            (tr + br) / 2,
+            br,
+            (br + bl) / 2,
+            bl,
+            (bl + tl) / 2,
+            (tl + br) / 2,
+        ]
+    )
 
 
 def create_box(data: npt.NDArray) -> npt.NDArray:
@@ -1305,3 +1342,7 @@ if acc_generate_2D_edge_meshes is not None:
     _generate_2D_edge_meshes = acc_generate_2D_edge_meshes
 else:  # pragma: no cover
     _generate_2D_edge_meshes = generate_2D_edge_meshes
+
+
+if acc_create_box_from_bounding is not None:
+    create_box_from_bounding = acc_create_box_from_bounding

--- a/napari/layers/shapes/_tests/test_triangulation.py
+++ b/napari/layers/shapes/_tests/test_triangulation.py
@@ -2,6 +2,7 @@ import importlib
 from unittest.mock import patch
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 ac = pytest.importorskip('napari.layers.shapes._accelerated_triangulate')
@@ -118,3 +119,24 @@ def test_generate_2D_edge_meshes(path, closed, bevel, expected):
 def test_remove_path_duplicates(data, expected, closed):
     result = ac.remove_path_duplicates(data, closed=closed)
     assert np.all(result == expected)
+
+
+@pytest.mark.usefixtures('_disable_jit')
+def test_create_box_from_bounding():
+    bounding = np.array([[0, 0], [2, 2]], dtype='float32')
+    box = ac.create_box_from_bounding(bounding)
+    assert box.shape == (9, 2)
+    npt.assert_array_equal(
+        box,
+        [
+            [0, 0],
+            [1, 0],
+            [2, 0],
+            [2, 1],
+            [2, 2],
+            [1, 2],
+            [0, 2],
+            [0, 1],
+            [1, 1],
+        ],
+    )

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -859,8 +859,12 @@ class Shapes(Layer):
         if len(self.data) == 0:
             extrema = np.full((2, self.ndim), np.nan)
         else:
-            maxs = np.max([np.max(d, axis=0) for d in self.data], axis=0)
-            mins = np.min([np.min(d, axis=0) for d in self.data], axis=0)
+            maxs = np.max(
+                [d._bounding_box[1] for d in self._data_view.shapes], axis=0
+            )
+            mins = np.min(
+                [d._bounding_box[0] for d in self._data_view.shapes], axis=0
+            )
             extrema = np.vstack([mins, maxs])
         return extrema
 
@@ -2312,7 +2316,7 @@ class Shapes(Layer):
         self._ndisplay_stored = copy(self._slice_input.ndisplay)
         self._update_dims()
 
-    def _add_shapes_to_view(self, shape_inputs, data_view):
+    def _add_shapes_to_view(self, shape_inputs, data_view: ShapeList):
         """Build new shapes and add them to the _data_view"""
 
         shape_inputs = tuple(shape_inputs)
@@ -2320,7 +2324,7 @@ class Shapes(Layer):
         # build all shapes
         sh_inp = tuple(
             (
-                shape_classes[ShapeType(st)](
+                shape_classes[st](
                     d,
                     edge_width=ew,
                     z_index=z,

--- a/napari/settings/_experimental.py
+++ b/napari/settings/_experimental.py
@@ -56,6 +56,23 @@ class ExperimentalSettings(EventedSettings):
         ),
     )
 
+    compiled_triangulation: bool = Field(
+        False,
+        title=trans._(
+            'Use C++ code to speedup creation and updates of Shapes layers'
+            '(requires optional dependencies)'
+        ),
+        description=trans._(
+            'When enabled, triangulation (breaking down polygons into '
+            "triangles that can be displayed by napari's graphics engine) is "
+            'sped up by using C++ code from the optional library '
+            'PartSegCore-compiled-backend. C++ code can cause bad crashes '
+            'called segmentation faults or access violations. If you '
+            'encounter such a crash while using this option please report '
+            'it at https://github.com/napari/napari/issues.'
+        ),
+    )
+
     class NapariConfig:
         # Napari specific configuration
         preferences_exclude = ('schema_version',)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ all = [
 ]
 optional = [
     "triangle ; platform_machine != 'arm64'",
+    "PartSegCore-compiled-backend>=0.15.8",
     "numba>=0.57.1",
     "zarr>=2.12.0", # needed by `builtins` (dask.array.from_zarr) to open zarr
 ]
@@ -762,6 +763,7 @@ ignore_errors = true
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
     "raise NotImplementedError()",
     "except ImportError:",
     "^ +\\.\\.\\.$",


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7346

# References and relevant issues

It may be a replacement for #6654 

# Description

This PR is using https://github.com/4DNucleome/PartSegCore-compiled-backend/pull/36 to perform triangulation. 

Used sweeping line algorithm from pointed PR allows having "polygon with holes" or "non-coherent polygons" so after this PR we could implement alternative to #6654 by addin "Multi polygon" shape. It will also allow to map multi components labels into shape. 


Current main:

![obraz](https...